### PR TITLE
Fix a typo to avoid rc-local.service enable error

### DIFF
--- a/mangdang/System/install.sh
+++ b/mangdang/System/install.sh
@@ -1,6 +1,6 @@
 # the command script to init system for mini pupper 
 set -x
 sudo cp rc.local /etc/
-sudo cp rc.local.service /lib/systemd/system/
-sudo systemctl enable rc-local
+sudo cp rc-local.service /lib/systemd/system/
+sudo systemctl enable rc-local.service
 sudo systemctl start rc-local.service

--- a/mangdang/System/rc-local.service
+++ b/mangdang/System/rc-local.service
@@ -25,4 +25,3 @@ GuessMainPID=no
 [Install]
 WantedBy=multi-user.target
 Alias=rc-local.service
-


### PR DESCRIPTION
This PR fixes the rc-local.service install error.

The current install script shows the following output while installing.

```
ubuntu@ubuntu:~/minipupper_ros_bsp/mangdang/System$ ./install.sh 
++ sudo cp rc.local /etc/
++ sudo cp rc.local.service /lib/systemd/system/
++ sudo systemctl enable rc-local
The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
Alias= settings in the [Install] section, and DefaultInstance= for template
units). This means they are not meant to be enabled using systemctl.
 
Possible reasons for having this kind of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/ or .requires/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
++ sudo systemctl start rc-local.service
```